### PR TITLE
bugfix: only download on add for FILE_DUMP datasets

### DIFF
--- a/app/controllers/vocabularies/new.js
+++ b/app/controllers/vocabularies/new.js
@@ -69,7 +69,9 @@ export default class VocabulariesNewController extends Controller {
       type: this.downloadType,
     });
     yield dataset.save();
-    yield this.createAndRunDownloadJob.perform(dataset);
+    if (this.downloadFormat?.value === TYPE_FILE_DUMP) {
+      yield this.createAndRunDownloadJob.perform(dataset);
+    }
     yield this.router.transitionTo('vocabulary', vocabularyMeta.id);
   }
 }

--- a/app/controllers/vocabulary/index.js
+++ b/app/controllers/vocabulary/index.js
@@ -4,6 +4,8 @@ import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 
+const TYPE_FILE_DUMP = 'http://vocabsearch.data.gift/dataset-types/FileDump';
+
 export default class VocabularyIndexController extends Controller {
   @service store;
   @service router;
@@ -49,7 +51,9 @@ export default class VocabularyIndexController extends Controller {
       type: downloadType,
     });
     yield dataset.save();
-    yield this.createAndRunDownloadJob(dataset);
+    if (downloadFormat.value === TYPE_FILE_DUMP) {
+      yield this.createAndRunDownloadJob(dataset);
+    }
     yield this.switchShowAddSource();
     this.router.refresh();
   }


### PR DESCRIPTION
Since it is not useful for LDES datasets and will only confuse users by showing a failed download instead of the "please wait for the LDES-consumer-manager to initialize the download" message