### PR TITLE
feat: add searchbar preview

### DIFF
--- a/app/components/webcomponent-snippet.hbs
+++ b/app/components/webcomponent-snippet.hbs
@@ -58,9 +58,17 @@
           search-endpoint="{{this.searchEndpoint}}"{{/if}}{{#if
           this.selectedLanguages
         }}
-          languages-string="{{this.selectedLanguageString}}"{{/if}}&gt; 
+          languages-string="{{this.selectedLanguageString}}"{{/if}}&gt;
         &lt;/vocab-search-bar&gt;
-      &lt;/body&gt; 
+      &lt;/body&gt;
     &lt;/html&gt;
     </code></pre>
+  <h1>Searchbar preview</h1>
+  <vocab-search-bar
+  query="{{this.query}}"
+  source-datasets="{{map-by "uri" (flatten (map-by "sourceDatasets" this.selectedVocabs))}}"
+  search-endpoint="{{this.searchEndpoint}}"
+  languages-string="{{this.selectedLanguageString}}"
+  >
+  </vocab-search-bar>
 </div>

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -35,5 +35,8 @@ module.exports = function (defaults) {
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
 
+  // import the vocab search bar component to allow showing it in a preview
+  app.import('node_modules/vocab-search-search-bar/dist/vocab-search-bar.js');
+
   return app.toTree();
 };

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   },
   "dependencies": {
     "date-fns": "^2.29.3",
-    "ember-resources": "^5.6.3"
+    "ember-resources": "^5.6.3",
+    "vocab-search-search-bar": "0.1.0"
   }
 }


### PR DESCRIPTION
With this PR a preview of the searchbar webcomponent is shown when configuring it (see image)
![image](https://github.com/redpencilio/frontend-vocabserver/assets/32643670/bcb231ba-73aa-407d-a2ab-84dc0798119a)
