### PR TITLE
move alias-logic to Vocabularies + use vocabs in webcomponent

### DIFF
--- a/app/components/vocab-alias.hbs
+++ b/app/components/vocab-alias.hbs
@@ -1,0 +1,31 @@
+{{#if this.editableVocab}}
+  <div>
+    <BsForm::Element::Control::Input 
+      @value={{this.newAlias}}
+      @onChange={{this.setNewAlias}}
+    />
+    <BsButton
+        @type="info"
+        @onClick={{this.saveVocabAlias}}
+    >
+      <BsIcon @name="spellcheck" />
+    </BsButton>
+    <BsButton
+        @type="danger"
+        @onClick={{this.stopEditingVocab}}
+    >
+      <BsIcon @name="x-square" />
+    </BsButton>
+  </div>
+  {{#if this.error}}
+    <span class="text-danger">{{this.error}}</span>
+  {{/if}}
+{{else}}
+  {{or (this.aliasString @vocab.alias) "*no alias*"}}
+  <BsButton
+      @type="info"
+      @onClick={{fn this.setVocabEdit @vocab}}
+    >
+      <BsIcon @name="pencil-square" />
+  </BsButton>
+{{/if}}

--- a/app/components/vocab-alias.js
+++ b/app/components/vocab-alias.js
@@ -1,0 +1,64 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import config from 'frontend-vocab-search-admin/config/constants';
+
+export default class VocabAliasComponent extends Component {
+  @service store;
+
+  @tracked editableVocab = null;
+  @tracked newAlias = null;
+  @tracked error = null;
+
+  aliasString(aliasUri) {
+    return aliasUri && aliasUri.startsWith(config.VOCABULARY_ALIAS_BASE)
+      ? aliasUri.replace(config.VOCABULARY_ALIAS_BASE, '')
+      : aliasUri;
+  }
+
+  aliasUri = (aliasString) =>
+    aliasString === '' ? '' : `${config.VOCABULARY_ALIAS_BASE}${aliasString}`;
+
+  @action
+  setVocabEdit(vocab) {
+    this.editableVocab = vocab;
+    this.newAlias = this.aliasString(vocab.alias);
+  }
+
+  @action
+  stopEditingVocab() {
+    this.editableVocab = null;
+    this.newAlias = null;
+    this.error = null;
+  }
+
+  @action
+  async saveVocabAlias() {
+    const newAliasUri = this.aliasUri(this.newAlias);
+
+    if (this.newAlias) {
+      // check if the URI does not already exist
+      // this makes the assumption only vocab aliases might have this URI base
+      const vocabWithSimilarUri = await this.store.query('vocabulary', {
+        'filter[alias]': newAliasUri,
+      });
+      if (vocabWithSimilarUri.length !== 0) {
+        const vocab = vocabWithSimilarUri[0];
+        this.error = `This alias is already used by the vocab '${vocab.name}'.`;
+        return;
+      }
+    }
+
+    // if empty, just remove the alias
+    this.editableVocab.alias = newAliasUri === '' ? null : newAliasUri;
+    await this.editableVocab.save();
+    this.stopEditingVocab();
+  }
+
+  @action
+  setNewAlias(newVal) {
+    this.newAlias = newVal;
+    this.error = null;
+  }
+}

--- a/app/components/vocab-alias.js
+++ b/app/components/vocab-alias.js
@@ -17,6 +17,15 @@ export default class VocabAliasComponent extends Component {
       : aliasUri;
   }
 
+  isValidUrl(string) {
+    try {
+      new URL(string);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+
   aliasUri = (aliasString) =>
     aliasString === '' ? '' : `${config.VOCABULARY_ALIAS_BASE}${aliasString}`;
 
@@ -33,15 +42,24 @@ export default class VocabAliasComponent extends Component {
     this.error = null;
   }
 
+  isValidAlias(alias) {
+    return !alias.includes(' ') && !alias.includes(',');
+  }
+
   @action
   async saveVocabAlias() {
+    this.newAlias = this.newAlias.trim();
+    if (!this.isValidAlias(this.newAlias)) {
+      this.error = `This alias is not a valid alias to use.`;
+      return;
+    }
     const newAliasUri = this.aliasUri(this.newAlias);
 
     if (this.newAlias) {
       // check if the URI does not already exist
       // this makes the assumption only vocab aliases might have this URI base
       const vocabWithSimilarUri = await this.store.query('vocabulary', {
-        'filter[alias]': newAliasUri,
+        'filter[:exact:alias]': newAliasUri,
       });
       if (vocabWithSimilarUri.length !== 0) {
         const vocab = vocabWithSimilarUri[0];

--- a/app/components/webcomponent-snippet.hbs
+++ b/app/components/webcomponent-snippet.hbs
@@ -28,7 +28,7 @@
     </form.element>
     <form.element
       @controlType='power-select-multiple'
-      @label='Search Datasets'
+      @label='Search vocabularies'
       @property='selectedVocabs'
       @options={{this.vocabularies}}
       @optionLabelPath='name'
@@ -54,7 +54,7 @@
         &lt;h1&gt;Search&lt;/h1&gt;
         &lt;vocab-search-bar{{#if this.query}}
           query="{{this.query}}"{{/if}}{{#if this.selectedVocabs.length}}
-          source-datasets="{{this.aliasesOrUris (flatten (map-by "sourceDatasets" this.selectedVocabs))}}"{{/if}}{{#if this.searchEndpoint}}
+          source-datasets="{{this.aliasesOrUris this.selectedVocabs}}"{{/if}}{{#if this.searchEndpoint}}
           search-endpoint="{{this.searchEndpoint}}"{{/if}}{{#if
           this.selectedLanguages
         }}
@@ -66,7 +66,7 @@
   <h1>Searchbar preview</h1>
   <vocab-search-bar
   query="{{this.query}}"
-  source-datasets="{{this.aliasesOrUris (flatten (map-by "sourceDatasets" this.selectedVocabs))}}"
+  source-datasets="{{this.aliasesOrUris this.selectedVocabs}}"
   search-endpoint="{{this.searchEndpoint}}"
   languages-string="{{this.selectedLanguageString}}"
   >

--- a/app/components/webcomponent-snippet.js
+++ b/app/components/webcomponent-snippet.js
@@ -28,10 +28,8 @@ export default class WebcomponentSnippetComponent extends Component {
     this.selectedLanguages = [];
     this.initData();
   }
-
-  // use the alias of a dataset, or uri if no alias is set
-  aliasesOrUris = (datasets) =>
-    datasets.map((dataset) => dataset.alias || dataset.uri);
+  // use the alias of a vocab, or uri if no alias is set
+  aliasesOrUris = (vocabs) => vocabs?.map((vocab) => vocab.alias || vocab.uri);
 
   async initData() {
     this.vocabularies = await this.store.findAll('vocabulary');

--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -12,5 +12,5 @@ export default {
     FILE_DUMP: 'http://vocabsearch.data.gift/dataset-types/FileDump',
     LDES: 'http://vocabsearch.data.gift/dataset-types/LDES'
   },
-  DATASET_ALIAS_BASE: 'https://my-application.com/dataset-alias/'
+  VOCABULARY_ALIAS_BASE: 'https://my-application.com/vocabulary-alias/'
 };

--- a/app/controllers/vocabulary/index.js
+++ b/app/controllers/vocabulary/index.js
@@ -13,18 +13,6 @@ export default class VocabularyIndexController extends Controller {
   @tracked size = 20;
   @tracked ldesDereference = false;
   @tracked ldesMaxRequests = 120;
-  @tracked editableDataset = null;
-  @tracked newAlias = null;
-  @tracked error = null;
-
-  aliasString(aliasUri) {
-    return aliasUri && aliasUri.startsWith(config.DATASET_ALIAS_BASE)
-      ? aliasUri.replace(config.DATASET_ALIAS_BASE, '')
-      : aliasUri;
-  }
-
-  aliasUri = (aliasString) =>
-    aliasString === '' ? '' : `${config.DATASET_ALIAS_BASE}${aliasString}`;
 
   @action
   async switchShowAddSource() {
@@ -72,50 +60,5 @@ export default class VocabularyIndexController extends Controller {
     }
     yield this.switchShowAddSource();
     this.router.refresh();
-  }
-
-  @action
-  setDatasetEdit(dataset) {
-    this.editableDataset = dataset;
-    this.newAlias = this.aliasString(dataset.alias);
-  }
-
-  @action
-  stopEditingDataset() {
-    this.editableDataset = null;
-    this.newAlias = null;
-    this.error = null;
-  }
-
-  @action
-  async saveDatasetAlias() {
-    const newAliasUri = this.aliasUri(this.newAlias);
-
-    if (this.newAlias) {
-      // check if the URI does not already exist
-      // this makes the assumption only dataset aliases might have this URI base
-      const datasetWithSimilarUri = await this.store.query('dataset', {
-        'filter[alias]': newAliasUri,
-        include: 'vocabulary',
-      });
-      if (datasetWithSimilarUri.length !== 0) {
-        const dataset = datasetWithSimilarUri[0];
-        this.error = `This alias is already used by the dataset '${
-          dataset.downloadPage
-        }' in vocabulary '${dataset.get('vocabulary.name')}'`;
-        return;
-      }
-    }
-
-    // if empty, just remove the alias
-    this.editableDataset.alias = newAliasUri === '' ? null : newAliasUri;
-    await this.editableDataset.save();
-    this.stopEditingDataset();
-  }
-
-  @action
-  setNewAlias(newVal) {
-    this.newAlias = newVal;
-    this.error = null;
   }
 }

--- a/app/models/dataset.js
+++ b/app/models/dataset.js
@@ -3,8 +3,6 @@ import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 export default class Dataset extends Model {
   @attr uri;
 
-  @attr alias;
-
   @attr title;
   @attr downloadPage;
   @attr modified;

--- a/app/models/vocabulary.js
+++ b/app/models/vocabulary.js
@@ -4,6 +4,7 @@ export default class VocabularyModel extends Model {
   @attr('string') name;
 
   @attr('string') uri;
+  @attr('string') alias;
 
   @hasMany('dataset') sourceDatasets;
   @belongsTo('shacl-node-shape') mappingShape;

--- a/app/templates/vocabularies/index.hbs
+++ b/app/templates/vocabularies/index.hbs
@@ -18,6 +18,7 @@
     <Content.header>
       <ThSortable @field="name" @currentSorting={{this.sort}} @label="Name" />
       <th>Actions</th>
+      <th>Alias</th>
     </Content.header>
     <Content.body as |vocab|>
       <td>
@@ -40,6 +41,9 @@
             <BsIcon @name='trash-fill' />
           </:buttonContent>
         </ConfirmationButton>
+      </td>
+      <td>
+        <VocabAlias @vocab={{vocab}}/>
       </td>
     </Content.body>
   </Table.content>

--- a/app/templates/vocabulary/index.hbs
+++ b/app/templates/vocabulary/index.hbs
@@ -24,7 +24,6 @@
       <ThSortable @field="type.pref-label" @currentSorting={{this.sort}} @label="Type" />
       <th>Last Update</th>
       <th>Actions</th>
-      <th>Alias</th>
     </Content.header>
     <Content.body as |dataset|>
       <td>
@@ -56,39 +55,6 @@
             <BsIcon @name='trash-fill' />
           </:buttonContent>
         </ConfirmationButton>
-      </td>
-      <td>
-        {{#if (eq this.editableDataset.uri dataset.uri)}}
-          <div>
-            <BsForm::Element::Control::Input 
-              @value={{this.newAlias}}
-              @onChange={{this.setNewAlias}}
-            />
-            <BsButton
-                @type="info"
-                @onClick={{this.saveDatasetAlias}}
-            >
-              <BsIcon @name="spellcheck" />
-            </BsButton>
-            <BsButton
-                @type="danger"
-                @onClick={{this.stopEditingDataset}}
-            >
-              <BsIcon @name="x-square" />
-            </BsButton>
-          </div>
-          {{#if this.error}}
-            <span class="text-danger">{{this.error}}</span>
-          {{/if}}
-        {{else}}
-          {{or (this.aliasString dataset.alias) "*no alias*"}}
-          <BsButton
-              @type="info"
-              @onClick={{fn this.setDatasetEdit dataset}}
-            >
-              <BsIcon @name="pencil-square" />
-          </BsButton>
-        {{/if}}
       </td>
     </Content.body>
   </Table.content>


### PR DESCRIPTION
The change is made to make vocabulary URIs (instead of dataset URIs) the main way to query datasets.
- move using "alias" to vocabs instead
- set the desired vocab in the webcomponent, instead of the datasets.