### PR TITLE
Webcomponent link + clean up /search 

### DIFF
--- a/app/components/webcomponent-snippet.hbs
+++ b/app/components/webcomponent-snippet.hbs
@@ -63,6 +63,12 @@
       &lt;/body&gt;
     &lt;/html&gt;
     </code></pre>
+    <p>
+      <strong>
+        For other attributes see 
+        <a href="https://github.com/vlizBE/vocabserver-webcomponent#attributesproperties" target="_blank" rel="noopener noreferrer">the readme of the webcomponent</a>
+      </strong>
+    </p>
   <h1>Searchbar preview</h1>
   <vocab-search-bar
   query="{{this.query}}"

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -14,8 +14,16 @@ export default class SearchRoute extends Route {
     const size = 15;
     const sort = null; // By relevance
     this.q = params.q;
+    // this makes this query the same as the webcomponent base query
+    const qStartMatch =
+      !this.q || this.q?.trim() === ''
+        ? '*'
+        : this.q
+            .split(' ')
+            .map((word) => `(${word}*|${word})`)
+            .join(' ');
     const filter = {
-      ':sqs:*': params.q,
+      ':sqs:prefLabel.*,tagLabels': qStartMatch,
     };
     return search('concepts', page, size, sort, filter, (searchData) => {
       const entry = searchData.attributes;

--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -18,7 +18,6 @@
       <tr>
         <th>URI</th>
         <th>prefLabel</th>
-        <th>In scheme</th>
       </tr>
     </thead>
     <tbody>
@@ -30,7 +29,6 @@
               {{lang}}: {{val}}
             {{/each-in}}
           </td>
-          <td>{{term.schemePrefLabel}}</td>
         </tr>
       {{/each}}
     </tbody>


### PR DESCRIPTION
- add link for webcomponent documentation
- remove inScheme column in /search (this is not used anymore and would always stay empty)
- use the same search query in /search as is used by the webcomponent (multiple prefix-matching search)