### PR TITLE
Update webcomponent version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27983,7 +27983,7 @@
     },
     "node_modules/vocab-search-search-bar": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/x-m-el/vocabserver-webcomponent.git#0069f3b575a8dab41c6e51c27efd9183280ee79d",
+      "resolved": "git+ssh://git@github.com/x-m-el/vocabserver-webcomponent.git#f89d3856e19d8789cd3d951f9cb3756cdce4ed70",
       "dependencies": {
         "@vaadin/multi-select-combo-box": "^24.2.6",
         "lit": "^2.6.1"


### PR DESCRIPTION
This version reflects the `selections` attribute (replaces `set-selection` attribute). This way, the selection can be set at any time and this attribute will always have all the selected URIs.