### PR TITLE
Feature: import/export vocabs using vocab-configs service ("vocabulary migration")

### DIFF
--- a/app/components/webcomponent-snippet.js
+++ b/app/components/webcomponent-snippet.js
@@ -32,7 +32,10 @@ export default class WebcomponentSnippetComponent extends Component {
   aliasesOrUris = (vocabs) => vocabs?.map((vocab) => vocab.alias || vocab.uri);
 
   async initData() {
-    this.vocabularies = await this.store.findAll('vocabulary');
+    this.vocabularies = await this.store.query('vocabulary', {
+      'page[number]': 0,
+      'page[size]': 999,
+    });
   }
 
   get scriptSrc() {

--- a/app/controllers/vocabulary/vocabulary-mapping-and-unification.js
+++ b/app/controllers/vocabulary/vocabulary-mapping-and-unification.js
@@ -78,6 +78,7 @@ export default class VocabularyMappingAndUnificationController extends Controlle
     nodeShape.vocabulary = this.model.dataset.get('vocabulary');
     await nodeShape.save();
     await Promise.all(nodeShape.propertyShapes.map((x) => x.save()));
+    await this.createAndRunUnifyVocabJob.perform();
     this.send('reloadModel');
   }
 

--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -23,7 +23,7 @@
     <tbody>
       {{#each this.model as |term|}}
         <tr>
-          <td><a href={{term.uri}}>{{term.uri}}</a></td>
+          <td><a href={{term.datasetEntityUri}}>{{term.datasetEntityUri}}</a></td>
           <td>
             {{#each-in (from-entries (entries term.prefLabel)) as |lang val|}}
               {{lang}}: {{val}}


### PR DESCRIPTION
see https://github.com/redpencilio/app-vocabsearch/pull/13

+ add a route /migrations to do export/imports

+ add component download-vocabs for export vocabs
	- choose vocabs with a search-supporting multiselect
	- allow selecting all vocabs as an option (to be able to do a "whole app" migration)
	- will start an exportTask and show the download url of the file when done.

+ add upload-vocabs component
	- upload file with vocabs to import
	- upload file and start task to import these vocabs
	- when task is successful, show a list of imported vocabs as a link

+ add support for files (via ember-file-upload)
+ move alias-string as a global helper for re-use
+ add string-set as an actual transform