### PR TITLE
Fix sorting of vocabularies

### DIFF
--- a/app/controllers/vocabularies/index.js
+++ b/app/controllers/vocabularies/index.js
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 export default class VocabulariesIndexController extends Controller {
   @service store;
-  @tracked sort = 'name';
+  @tracked sort = ':no-case:name';
   @tracked page = 0;
   @tracked size = 20;
 

--- a/app/templates/vocabularies/index.hbs
+++ b/app/templates/vocabularies/index.hbs
@@ -16,7 +16,7 @@
   </Table.menu>
   <Table.content @class="table table-striped w-100" as |Content|>
     <Content.header>
-      <ThSortable @field="name" @currentSorting={{this.sort}} @label="Name" />
+      <ThSortable @field=":no-case:name" @currentSorting={{this.sort}} @label="Name" />
       <th>Actions</th>
       <th>Alias</th>
     </Content.header>


### PR DESCRIPTION
mu-cl-resources sort sometimes does not work as expected because it uses a `SORT BY (MAX () )` in the query, which virtuoso does not handle correctly.

A fix is to add :no-case:, which will sort irregardless of case (which is nicer anyway) and fixes this bug, fixing the sorting.