### PR TITLE
fix download button message for LDES feeds

### DIFF
--- a/app/components/dataset-status.hbs
+++ b/app/components/dataset-status.hbs
@@ -2,8 +2,8 @@
   {{format-date this.task.created "dd/MM/yyyy 'at' HH:mm"}} - <TaskStatus @task={{this.task}} />
 {{else}}
   {{#if this.isDump}}
-    please init download
+    please start download
   {{else}}
-    please wait for the LDES-consumer-manager to initialize the download
+    LDES-consumer-manager manages LDES feed. Press button to start pipeline with already consumed data.
   {{/if}}
 {{/if}}

--- a/app/components/mapping-shape-creator.hbs
+++ b/app/components/mapping-shape-creator.hbs
@@ -100,7 +100,6 @@ FILTER NOT EXISTS {?entity <http://www.w3.org/2002/07/owl#deprecated> &quot;true
     {{#let (await (filter-count-input-get-task filterInput)) as |task|}}
       <BsAlert @type="secondary" @onDismiss={{fn this.deleteModel filterInput}}>
         <:header>
-          {{log task}}
           Performing filter test...{{#if task}} <TaskStatus @task={{task}} @onTaskFinished={{this.reloadFilterIO}} /> {{/if}}
         </:header>
         <:body>


### PR DESCRIPTION
The text is confusing as it makes the assumption a job will be started to show the progress of LDES-consumer-manager, which is not the case.